### PR TITLE
ofShader/GLES2: fix begin/end cycle

### DIFF
--- a/libs/openFrameworks/gl/ofGLES2Renderer.cpp
+++ b/libs/openFrameworks/gl/ofGLES2Renderer.cpp
@@ -1129,8 +1129,9 @@ void ofGLES2Renderer::beginCustomShader(ofShader & shader){
 	currentShader = shader;
 }
 
+//----------------------------------------------------------
 void ofGLES2Renderer::endCustomShader(){
-	beginCustomShader(defaultShader);
+	defaultShader.begin();
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -345,14 +345,12 @@ bool ofShader::isLoaded(){
 
 //--------------------------------------------------------------
 void ofShader::begin() {
-	if (bLoaded){
+	if (bLoaded && activeProgram!=program){
 		glUseProgram(program);
-        if(activeProgram!=program) {
-            prevActiveProgram = activeProgram;
-            activeProgram = program;
-            if(!ofGLIsFixedPipeline()){
-                ofGetGLES2Renderer()->beginCustomShader(*this);
-            }
+        prevActiveProgram = activeProgram;
+        activeProgram = program;
+        if(!ofGLIsFixedPipeline()){
+            ofGetGLES2Renderer()->beginCustomShader(*this);
         }
 	}
 }


### PR DESCRIPTION
I think this fixes it for every case, the default shader wasn't being begun when a custom shader was ended. i've gone back to how the shader behaved in the begin call so it doesn't call glProgram if it's already active if you can test it and see if that works in iphone too, if it doesn't feel free to change ofShader::begin to what you had before
