### PR TITLE
iOS 5 Sound Crash Fix

### DIFF
--- a/addons/ofxiOS/src/video/AVFoundationVideoPlayer.m
+++ b/addons/ofxiOS/src/video/AVFoundationVideoPlayer.m
@@ -338,16 +338,28 @@ static const NSString * ItemStatusContext;
     }
     
     NSDictionary * audioOutputSettings = nil;
-    audioOutputSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-                           [NSNumber numberWithInt:kAudioFormatLinearPCM], AVFormatIDKey,
-                           [NSNumber numberWithFloat:preferredHardwareSampleRate], AVSampleRateKey,
-                           [NSNumber numberWithInt:numOfChannels], AVNumberOfChannelsKey,
-                           [NSData dataWithBytes:&channelLayout length:sizeof(AudioChannelLayout)], AVChannelLayoutKey,
-                           [NSNumber numberWithInt:16], AVLinearPCMBitDepthKey,
-                           [NSNumber numberWithBool:NO], AVLinearPCMIsNonInterleaved,
-                           [NSNumber numberWithBool:NO], AVLinearPCMIsFloatKey,
-                           [NSNumber numberWithBool:NO], AVLinearPCMIsBigEndianKey,
-                           nil];
+	
+	if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_5_1) {
+		audioOutputSettings = [NSDictionary dictionaryWithObjectsAndKeys:
+							   [NSNumber numberWithInt:kAudioFormatLinearPCM], AVFormatIDKey,
+							   [NSNumber numberWithFloat:preferredHardwareSampleRate], AVSampleRateKey,
+							   [NSNumber numberWithInt:16], AVLinearPCMBitDepthKey,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsNonInterleaved,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsFloatKey,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsBigEndianKey,
+							   nil];
+	} else {
+		audioOutputSettings = [NSDictionary dictionaryWithObjectsAndKeys:
+							   [NSNumber numberWithInt:kAudioFormatLinearPCM], AVFormatIDKey,
+							   [NSNumber numberWithFloat:preferredHardwareSampleRate], AVSampleRateKey,
+							   [NSNumber numberWithInt:numOfChannels], AVNumberOfChannelsKey,
+							   [NSData dataWithBytes:&channelLayout length:sizeof(AudioChannelLayout)], AVChannelLayoutKey,
+							   [NSNumber numberWithInt:16], AVLinearPCMBitDepthKey,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsNonInterleaved,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsFloatKey,
+							   [NSNumber numberWithBool:NO], AVLinearPCMIsBigEndianKey,
+							   nil];
+	}
     
     NSArray * audioTracks = [self.asset tracksWithMediaType:AVMediaTypeAudio];
     if([audioTracks count] > 0) {


### PR DESCRIPTION
**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '**\* -[AVAssetReaderTrackOutput initWithTrack:outputSettings:] AVAssetReaderTrackOutput does not currently support AVNumberOfChannelsKey or AVChannelLayoutKey'
**\* First throw call stack:
(0x3411b8bf 0x3213d1e5 0x37a71789 0x37a71005 0x41366d 0x412e6d 0x3698cd55 0x36997e8d 0x340ee2dd 0x340714dd 0x340713a5 0x324c6fcd 0x372c7743 0x406507 0xac45 0x8fd8):

Fixes Crash associated with the above (even though the iOS5 spec says those functions are supported they are not).
Crashes on iOS 5 only.
Devices tested: 
-iPhone 3GS (iOS 5.0.1)
-iPhone 4S (iOS 5.1)
